### PR TITLE
Keep quiet WebSocket clients alive

### DIFF
--- a/app/models/ScriptBoard.java
+++ b/app/models/ScriptBoard.java
@@ -25,7 +25,13 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import play.libs.Akka;
+import scala.concurrent.duration.Duration;
 
 public class ScriptBoard extends UntypedActor {
   private static ObjectMapper mapper = new ObjectMapper();
@@ -42,7 +48,41 @@ public class ScriptBoard extends UntypedActor {
   private static EventBus<Map> eventBus = new EventBus();
 
   private static Random rand = new Random();
-  private static HashMap<String, Client> clients = new HashMap<>();
+  // ConcurrentHashMap: the keepalive scheduler thread iterates this map
+  // while the actor thread adds/removes clients.
+  private static Map<String, Client> clients = new ConcurrentHashMap<>();
+
+  // One shared keepalive tick for every player socket. Proxies in front of
+  // Breadboard commonly kill a WebSocket after 60s without server-to-client
+  // traffic (nginx's proxy_read_timeout defaults to 60s), and a static graph
+  // can legitimately stay silent for longer than that. Verified on prod
+  // 2026-07-11: nginx closed quiet-but-alive clients with code 1006 after
+  // exactly 60s of upstream silence. Clients ignore messages without a key
+  // they recognize, so this is a no-op for every frontend version. One
+  // scheduler for all clients - never one timer per connection.
+  private static final long KEEPALIVE_INTERVAL_MS = 25000;
+  private static final AtomicBoolean keepaliveStarted = new AtomicBoolean(false);
+
+  private static void ensureKeepalive() {
+    if (!keepaliveStarted.compareAndSet(false, true)) return;
+    Akka.system().scheduler().schedule(
+        Duration.create(KEEPALIVE_INTERVAL_MS, TimeUnit.MILLISECONDS),
+        Duration.create(KEEPALIVE_INTERVAL_MS, TimeUnit.MILLISECONDS),
+        new Runnable() {
+          public void run() {
+            ObjectNode keepalive = Json.newObject();
+            keepalive.put("keepalive", System.currentTimeMillis());
+            for (Client client : clients.values()) {
+              try {
+                client.out.write(keepalive);
+              } catch (Exception e) {
+                // Dead socket; the client's own disconnect path reaps it.
+              }
+            }
+          }
+        },
+        Akka.system().dispatcher());
+  }
 
   // AMT lifecycle timers scheduled by the HitCreated handler. Tracked so they can be
   // cancelled on reload / on re-submit instead of being orphaned (MEMORY_LEAKS.md L6).
@@ -73,7 +113,7 @@ public class ScriptBoard extends UntypedActor {
     results = new HashMap();
     mapper = new ObjectMapper();
     admins = new ArrayList<>();
-    clients = new HashMap<>();
+    clients = new ConcurrentHashMap<>();
     eventTracker = new EventTracker();
     manager = new ScriptEngineManager();
     eventBus.clear();
@@ -270,6 +310,7 @@ public class ScriptBoard extends UntypedActor {
   }
 
   public static void addClient(String experimentIdString, String experimentInstanceIdString, String clientId, final WebSocket.In<JsonNode> in, final ThrottledWebSocketOut out) throws Exception {
+    ensureKeepalive();
     try {
       Long experimentId = Long.parseLong(experimentIdString);
       Long experimentInstanceId = Long.parseLong(experimentInstanceIdString);


### PR DESCRIPTION
## Summary

Participants can legitimately remain on a static screen or in a waiting room without receiving server-to-client updates. Reverse proxies may interpret this upstream silence as a dead WebSocket and close the connection, even while the browser continues sending client-to-server heartbeats.

This PR adds one process-wide server-to-client keepalive every 25 seconds. It does not create a timer per connection and requires no experiment-specific keepalive code.

Related to #49, which discusses WebSocket ping/pong, disconnect detection, and proxy-related connection problems.

## Why client heartbeats are insufficient

Client heartbeats travel from the browser to Breadboard. A reverse proxy’s upstream read timeout is reset by traffic in the opposite direction—from Breadboard toward the browser.

A participant can therefore continue sending heartbeats while the proxy closes the connection because Breadboard has sent nothing recently.

## Implementation

- Start one recurring Akka scheduler task when the first client connects.
- Send a lightweight JSON keepalive message to every connected client every 25 seconds.
- Use `ConcurrentHashMap` for the client registry because the scheduler iterates it while actor threads add or replace clients.
- Leave existing frontend behavior unchanged; current clients ignore the unrecognized `keepalive` field.
- Continue relying on the normal disconnect path to remove dead clients.

Only one scheduler task is created for the Breadboard process, regardless of the number of clients. Each client receives 2.4 keepalive messages per minute. The JSON application payload is approximately 27 bytes, or about 1.1 bytes per second per connected client before WebSocket and network framing.

## Validation

A raw WebSocket probe disabled protocol-level pings and compared clients that sent application heartbeats with clients that remained completely quiet.

Before this change, the production reverse proxy closed quiet upstream connections with WebSocket code 1006 after approximately 60 seconds without server-to-client traffic. Client-to-server heartbeats did not prevent the closure.

With this change, both heartbeat-sending and completely quiet clients remained connected for the full 180-second probe. They received server keepalives at approximately 25-second intervals.

A longer 80-minute stress test with
[`human-nature-lab/two-door-trust-game@07f40e6`](https://github.com/human-nature-lab/two-door-trust-game/tree/07f40e61ad584b58d0d8ffd41c115e2fb3fe3175)
used 100 simulated WebSocket clients. The workload included periodic heartbeats, staggered connections, long waiting periods, intentional disconnects, and same-ID reconnections. CAPTCHA was disabled for the automated clients.

All 100 clients started, including clients that remained in waiting states for extended periods. Same-ID reconnections succeeded, and no clients remained active at the end of the run.

The 100-client deployment also contained the timer-resource changes submitted separately. The stress test therefore validates keepalive and reconnection behavior under load; timer-thread and memory attribution is documented in the timer-resource PR.

This branch is independently based on `dev` and does not depend on the timer-resource PR. The complete upstream test suite passed:

```text
175 tests, 0 failures, 0 errors
```

The distribution built successfully using Java 8 and sbt 0.13.18:

```sh
sbt -java-home /path/to/jdk8 clean test dist
```

## Scope

This is an application-level compatibility measure for deployments behind reverse proxies with upstream idle timeouts. Deployments using protocol-level WebSocket ping frames or sufficiently long proxy timeouts may not require it.

This change keeps quiet connections alive; it does not provide general experiment isolation or replace Breadboard’s existing disconnect handling.